### PR TITLE
tor binary is now compiled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 FROM golang:buster AS go-build
 
 # Build /go/bin/obfs4proxy & /go/bin/meek-server
-RUN go get -v gitlab.com/yawning/obfs4.git/obfs4proxy \
- && go get -v git.torproject.org/pluggable-transports/meek.git/meek-server \
+RUN go install -v gitlab.com/yawning/obfs4.git/obfs4proxy@latest \
+ && go install -v git.torproject.org/pluggable-transports/meek.git/meek-server@latest \
  && cp -rv /go/bin /usr/local/
 
 FROM debian:buster-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,11 +35,20 @@ RUN apt-get update \
  && echo "deb-src https://deb.torproject.org/torproject.org buster main" >> /etc/apt/sources.list.d/tor-apt-sources.list \
  # Install tor with GeoIP and obfs4proxy & backup torrc \
  && apt-get update \
+ && apt-get install -y build-essential fakeroot devscripts libcap-dev \
+ && apt-get build-dep -y tor \
+ && apt-get source tor \
+ && cd tor-*/ \
+ && debuild -rfakeroot -uc -us \
+ && cd .. \
+ && dpkg -i tor_*.deb tor-*.deb \
+ && tor --version \
+ && rm -rf tor-*/ tor_*.deb tor-*.deb \
  && apt-get install --no-install-recommends --no-install-suggests -y \
         pwgen \
         iputils-ping \
-        tor \
-        tor-geoipdb \
+ #       tor \
+ #       tor-geoipdb \
         deb.torproject.org-keyring \
  && mkdir -pv /usr/local/etc/tor/ \
  && mv -v /etc/tor/torrc /usr/local/etc/tor/torrc.sample \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:buster AS go-build
 
 # Build /go/bin/obfs4proxy & /go/bin/meek-server
-RUN go get -v git.torproject.org/pluggable-transports/obfs4.git/obfs4proxy \
+RUN go get -v gitlab.com/yawning/obfs4.git/obfs4proxy \
  && go get -v git.torproject.org/pluggable-transports/meek.git/meek-server \
  && cp -rv /go/bin /usr/local/
 
@@ -46,10 +46,11 @@ RUN apt-get update \
  && mkdir tor-install \
  && cd tor-install/ \
  && apt-get source tor \
- && cd tor-install/tor-*/ \
+ && cd tor-*/ \
  && debuild -rfakeroot -uc -us \
- && cd tor-install/ \
+ && cd .. \
  && dpkg -i tor_*.deb tor-*.deb \
+ && cd .. \
  && rm -rf tor-install/ \
  && tor --version \
  && apt-get install --no-install-recommends --no-install-suggests -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,13 @@ RUN apt-get update \
  && echo "deb-src https://deb.torproject.org/torproject.org buster main" >> /etc/apt/sources.list.d/tor-apt-sources.list \
  # Install tor with GeoIP and obfs4proxy & backup torrc \
  && apt-get update \
- && apt-get install -y build-essential fakeroot devscripts libcap-dev \
- && apt-get build-dep -y tor \
+ && apt-get install --no-install-recommends --no-install-suggests -y \
+        build-essential \
+        fakeroot \
+        devscripts \
+        libcap-dev \
+ && apt-get build-dep --no-install-recommends --no-install-suggests -y \
+        tor \
  && apt-get source tor \
  && cd tor-*/ \
  && debuild -rfakeroot -uc -us \

--- a/Dockerfile_steps.docker
+++ b/Dockerfile_steps.docker
@@ -2,7 +2,7 @@
 FROM golang:buster AS go-build
 
 # Build /go/bin/obfs4proxy & /go/bin/meek-server
-RUN go get -v git.torproject.org/pluggable-transports/obfs4.git/obfs4proxy
+RUN go get -v gitlab.com/yawning/obfs4.git/obfs4proxy
 RUN go get -v git.torproject.org/pluggable-transports/meek.git/meek-server
 RUN cp -rv /go/bin /usr/local/
 
@@ -44,12 +44,10 @@ RUN apt-get build-dep --no-install-recommends --no-install-suggests -y \
         tor \
         deb.torproject.org-keyring
 RUN mkdir tor-install
-RUN cd tor-install/
-RUN apt-get source tor
-RUN cd tor-install/tor-*/
-RUN debuild -rfakeroot -uc -us
-RUN cd tor-install/
-RUN dpkg -i tor_*.deb tor-*.deb
+RUN cd tor-install/ && apt-get source tor
+RUN cd tor-install/tor-*/ && debuild -rfakeroot -uc -us
+RUN cd tor-install/ && ls -la
+RUN cd tor-install/ && dpkg -i tor_*.deb tor-*.deb
 RUN rm -rf tor-install/
 RUN tor --version
 RUN apt-get install --no-install-recommends --no-install-suggests -y \

--- a/Dockerfile_steps.docker
+++ b/Dockerfile_steps.docker
@@ -1,0 +1,91 @@
+# Dockerfile for Tor Relay Server with obfs4proxy (Multi-Stage build)
+FROM golang:buster AS go-build
+
+# Build /go/bin/obfs4proxy & /go/bin/meek-server
+RUN go get -v git.torproject.org/pluggable-transports/obfs4.git/obfs4proxy
+RUN go get -v git.torproject.org/pluggable-transports/meek.git/meek-server
+RUN cp -rv /go/bin /usr/local/
+
+FROM debian:buster-slim
+MAINTAINER RJ dbarj@example.com
+
+ARG GPGKEY=A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89
+ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE="True"
+ARG DEBIAN_FRONTEND=noninteractive
+ARG found=""
+
+# Set a default Nickname
+ENV TOR_NICKNAME=Tor4
+ENV TOR_USER=tord
+ENV TERM=xterm
+
+# Install prerequisites
+RUN apt-get update
+RUN apt-get install --no-install-recommends --no-install-suggests -y \
+        apt-transport-https \
+        ca-certificates \
+        dirmngr \
+        apt-utils \
+        gnupg \
+        curl
+# Add torproject.org Debian repository for buster Tor version
+RUN curl https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --import
+RUN gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | apt-key add -
+RUN echo "deb https://deb.torproject.org/torproject.org buster main"   >  /etc/apt/sources.list.d/tor-apt-sources.list
+RUN echo "deb-src https://deb.torproject.org/torproject.org buster main" >> /etc/apt/sources.list.d/tor-apt-sources.list
+# Install tor with GeoIP and obfs4proxy & backup torrc
+RUN apt-get update
+RUN apt-get install --no-install-recommends --no-install-suggests -y \
+        build-essential \
+        fakeroot \
+        devscripts \
+        libcap-dev
+RUN apt-get build-dep --no-install-recommends --no-install-suggests -y \
+        tor \
+        deb.torproject.org-keyring
+RUN mkdir tor-install
+RUN cd tor-install/
+RUN apt-get source tor
+RUN cd tor-install/tor-*/
+RUN debuild -rfakeroot -uc -us
+RUN cd tor-install/
+RUN dpkg -i tor_*.deb tor-*.deb
+RUN rm -rf tor-install/
+RUN tor --version
+RUN apt-get install --no-install-recommends --no-install-suggests -y \
+        pwgen \
+        iputils-ping
+#        deb.torproject.org-keyring \
+#        tor \
+#        tor-geoipdb \
+RUN mkdir -pv /usr/local/etc/tor/
+RUN mv -v /etc/tor/torrc /usr/local/etc/tor/torrc.sample
+RUN apt-get purge --auto-remove -y \
+        apt-transport-https \
+        dirmngr \
+        apt-utils \
+        gnupg
+RUN apt-get clean
+RUN rm -rf /var/lib/apt/lists/*
+# Rename Debian unprivileged user to tord
+RUN usermod -l $TOR_USER debian-tor
+RUN groupmod -n $TOR_USER debian-tor
+
+# Copy obfs4proxy & meek-server
+COPY --from=go-build /usr/local/bin/ /usr/local/bin/
+
+# Copy Tor configuration file
+COPY ./torrc /etc/tor/torrc
+
+# Copy docker-entrypoint
+COPY ./scripts/ /usr/local/bin/
+
+# Persist data
+VOLUME /etc/tor /var/lib/tor
+
+# ORPort, DirPort, SocksPort, ObfsproxyPort, MeekPort
+# EXPOSE 9001 9030 9050 54444 7002
+EXPOSE 10050 10051 4431 8001 5301
+
+ENTRYPOINT ["docker-entrypoint"]
+CMD ["tor", "-f", "/etc/tor/torrc"]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ docker run -d --init --name=tor-server_relay_1 --net=host \
 -e TOR_NICKNAME=Tor4 \
 -e CONTACT_EMAIL=tor4@example.org \
 -v $PWD/tor-data:/var/lib/tor \
---restart=always chriswayg/tor-server
+--restart=always dbarj/tor-server
 ```
 
 This command will run a Tor relay server with a safe default configuration (not as an exit node). The server will autostart after restarting the host system. If you do not change the default Nickname 'Tor4', the startup script will add a randomized, pronouncable suffix to create a unique name. All Tor data will be preserved in the mounted Data Directory, even if you upgrade or remove the container.
@@ -83,7 +83,7 @@ docker run -d --init --name=tor-server_relay_1 --net=host \
 -e CONTACT_EMAIL=tor4@example.org \
 -v $PWD/tor-data:/var/lib/tor \
 -v $PWD/torrc:/etc/tor/torrc \
---restart=always chriswayg/tor-server
+--restart=always dbarj/tor-server
 ```
 
 ### Move or upgrade the Tor relay
@@ -103,12 +103,12 @@ You can also reuse these identity keys from a previous Tor relay server installa
 
 ### Run Tor using docker-compose (recommended)
 
-Adapt the example `docker-compose.yml` with your settings or clone it from [Github](https://github.com/chriswayg/tor-server).
+Adapt the example `docker-compose.yml` with your settings or clone it from [Github](https://github.com/dbarj/docker-tor-server).
 ```
 version: '2.2'
 services:
   relay:
-    image: chriswayg/tor-server
+    image: dbarj/tor-server
     init: true
     restart: always
     network_mode: host
@@ -125,7 +125,7 @@ services:
 
 - Configure the `docker-compose.yml` and optionally the `torrc` file, with your individual settings. Possibly install `git` first.
 ```
-cd /opt && git clone https://github.com/chriswayg/tor-server.git && cd tor-server
+cd /opt && git clone https://github.com/dbarj/docker-tor-server.git && cd docker-tor-server
 nano docker-compose.yml
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.2'
 services:
   relay:
-    image: chriswayg/tor-server
+    image: dbarj/tor-server
     init: true
     restart: always
     network_mode: host

--- a/scripts/docker-entrypoint
+++ b/scripts/docker-entrypoint
@@ -14,6 +14,9 @@ chown -Rv ${TOR_USER}:${TOR_USER} /var/lib/tor
 chmodd 700 /var/lib/tor
 chmodf 600 /var/lib/tor
 
+chmodd 700 /var/log/tor
+chmodf 600 /var/log/tor
+
 if [ ! -e /tor-config-done ]; then
     touch /tor-config-done   # only run this once
 


### PR DESCRIPTION
Instead of getting latest version of the binary, I've changed the Dockerfile to compile it.

Major reason is that some versions ( like this one used for Raspberry Pi or most ARM boards - armhf - https://deb.torproject.org/torproject.org/dists/buster/main/binary-armhf/Packages ) have some dependencies issues as the tor version binary is pretty old (0.4.2.7) and only geoipdb is in (0.4.4.5).